### PR TITLE
Feat/add backlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# backlinks
+links.json

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next",
     "dev:watch": "next-remote-watch ./posts",
-    "build": "next build",
+    "build:backlinks": "node ./scripts/post-links",
+    "build": "npm run build:backlinks && next build",
     "start": "next start"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "private": true,
-  "type": "module",
   "scripts": {
     "dev": "next",
     "dev:watch": "next-remote-watch ./posts",

--- a/scripts/post-links.js
+++ b/scripts/post-links.js
@@ -1,5 +1,10 @@
-import fs from 'fs'
-import { getAllPostData } from '../utils/getAllPosts.js'
+const fs = require('fs')
+const path = require('path')
+const matter = require('gray-matter')
+
+const ESSAYS_PATH = path.join(process.cwd(), "posts", "essays");
+const NOTES_PATH = path.join(process.cwd(), "posts", "notes");
+const PATTERNS_PATH = path.join(process.cwd(), "posts", "patterns");
 
 // Extract all instances of substrings between double brackets [[]] from a long string
 const bracketsExtractor = (str) => {
@@ -33,6 +38,34 @@ const getExcerpt = (str) => {
     if (!str) return ''
     const stripped = stripExcerpt(str)
     return `${stripped.substring(0, 280).trimEnd()}...`
+}
+
+const getDataForBacklinks = (fileNames, filePath) => fileNames.map(fileName => {
+    const file = fs.readFileSync(path.join(filePath, fileName), "utf8");
+    const { content, data } = matter(file);
+    const slug = fileName.replace(/\.mdx?$/, "");
+    const { title, aliases, growthStage } = data;
+
+    return {
+        content,
+        slug,
+        title,
+        aliases,
+        growthStage
+    }
+})
+
+const getAllPostData = () => {
+    // get all note files
+    const essayFiles = fs.readdirSync(ESSAYS_PATH);
+    const noteFiles = fs.readdirSync(NOTES_PATH);
+    const patternFiles = fs.readdirSync(PATTERNS_PATH);
+
+    const essaysData = getDataForBacklinks(essayFiles, ESSAYS_PATH);
+    const notesData = getDataForBacklinks(noteFiles, NOTES_PATH);
+    const patternsData = getDataForBacklinks(patternFiles, PATTERNS_PATH);
+    
+    return [...essaysData, ...notesData, ...patternsData];
 }
 
 ;(function () {

--- a/scripts/post-links.js
+++ b/scripts/post-links.js
@@ -1,0 +1,108 @@
+import fs from 'fs'
+import { getAllPostData } from '../utils/getAllPosts.js'
+
+// Extract all instances of substrings between double brackets [[]] from a long string
+const bracketsExtractor = (str) => {
+    const matcher = /((?!\])(?!\[).)+/gs
+    return str.match(matcher)
+}
+
+const matchCodeBlocks = new RegExp('```[\\d\\D]*?```', 'g')
+
+/**
+ * I need to work out rendering the html previews for excerpts. Until then, this function
+ * is for stripping out JSX tags, newline characters, extra spaces, double brackets and code
+ * blocks so that an excerpt can be shown as a string of content.
+ * @param str raw markdown string
+ * @returns stripped string
+ */
+const stripExcerpt = (str) =>
+    str
+        .substring(0, 700) // Work on a smaller substring for efficiency
+        .replace(/(<([^>]+)>)/gi, '') // Remove all JSX tags
+        .replace(/\r?\n|\r/g, ' ') // Replace all line breaks
+        .replace(/{' '}/g, '') // Replace spaces in braces that occur in JSX components
+        .replace(/\s+/g, ' ') // Replaces all whitespace exceeding one space character
+        .replace(/\[\[/g, '') // Remove brackets from excerpt
+        .replace(/\]\]/g, '')
+        .replace(matchCodeBlocks, '') // Remove code blocks
+        .trim()
+
+const getExcerpt = (str) => {
+    if (!str) return ''
+    const stripped = stripExcerpt(str)
+    return `${stripped.substring(0, 280).trimEnd()}...`
+}
+
+;(function () {
+    // Get content and frontmatter for each post
+    const totalPostData = getAllPostData()
+
+    // Create initial objects. Identify each by a combined title and aliases identifier
+    // Initialise empty outbound and inbound link arrays
+    const posts = totalPostData.map(({ title, aliases, slug, growthStage }) => ({
+        ids: [title, ...(aliases ? aliases : [])],
+        slug,
+        growthStage,
+        outboundLinks: [],
+        inboundLinks: []
+    }))
+
+    // Get all outbound links
+    totalPostData.forEach((postData, index) => {
+        const { content } = postData
+        // Get all substrings between brackets from post body
+        const bracketContents = bracketsExtractor(content)
+        bracketContents?.forEach((alias) => {
+            // If matched text is an alias of another post
+            const match = posts.find((p) => {
+                // If an alias was found between JSX tags in the markdown string, it may contain undesirable substrings
+                const normalisedAlias = alias
+                    .replace(/\n/g, '')
+                    .replace(/\s+/g, ' ') // Replaces all whitespace exceeding one space character
+                    .replace(`{' '}`, ' ')
+                    .replace(`{" "}`, ' ')
+                return p.ids.includes(normalisedAlias)
+            })
+
+            if (match) {
+                // Get data for post that was referenced in the link
+                const matchedPostData = totalPostData.find((p) => p.title === match.ids[0])
+                const excerpt = getExcerpt(matchedPostData?.content)
+                // Add it to the outbound links
+                posts[index].outboundLinks.push({
+                    matchedId: alias,
+                    title: match.ids[0],
+                    slug: match.slug,
+                    growthStage: match.growthStage,
+                    excerpt
+                })
+            }
+        })
+    })
+
+    // Get inbound links for all posts. For each post (first loop), compare with all other posts (second loop)
+    for (const outerPost of posts) {
+        const outerPostTitle = outerPost.ids[0]
+
+        for (const innerPost of posts) {
+            const innerPostTitle = innerPost.ids[0]
+
+            // If inner post's outboundLinks contains a reference to the outer post,
+            // then the outer post must have the inner post as an inbound link
+            if (innerPost.outboundLinks.some((link) => link.title === outerPostTitle)) {
+                const matchedPostData = totalPostData.find((p) => p.title === innerPostTitle)
+                const excerpt = getExcerpt(matchedPostData?.content)
+
+                outerPost.inboundLinks.push({
+                    title: innerPostTitle,
+                    excerpt,
+                    slug: innerPost.slug,
+                    growthStage: innerPost.growthStage
+                })
+            }
+        }
+    }
+
+    fs.writeFile('links.json', JSON.stringify(posts), () => console.log('links recorded'))
+})()

--- a/scripts/post-links.js
+++ b/scripts/post-links.js
@@ -3,6 +3,7 @@ import { getAllPostData } from '../utils/getAllPosts.js'
 
 // Extract all instances of substrings between double brackets [[]] from a long string
 const bracketsExtractor = (str) => {
+    if(!str) return []
     const matcher = /((?!\])(?!\[).)+/gs
     return str.match(matcher)
 }

--- a/templates/EssayTemplate.js
+++ b/templates/EssayTemplate.js
@@ -16,6 +16,7 @@ export default function EssayTemplate({
     frontMatter,
     components,
     slug,
+    backlinks
 }) {
     return (
         <>
@@ -54,6 +55,10 @@ export default function EssayTemplate({
             <StyledMain>
                 <ProseWrapper>
                     <MDXRemote {...source} components={components} />
+                    {/* todo: replace this with a proper component */}
+                    {backlinks.length ? <pre style={{ whiteSpace: 'pre-wrap' }}>
+                        {JSON.stringify(backlinks, 4, null)}
+                    </pre> : null}
                 </ProseWrapper>
             </StyledMain>
             <TwitterReply

--- a/templates/NoteTemplate.js
+++ b/templates/NoteTemplate.js
@@ -16,6 +16,7 @@ export default function NoteTemplate({
     frontMatter,
     components,
     slug,
+    backlinks
 }) {
     return (
         <>
@@ -54,6 +55,10 @@ export default function NoteTemplate({
             <StyledMain>
                 <ProseWrapper>
                     <MDXRemote {...source} components={components} />
+                    {/* todo: replace this with a proper component */}
+                    {backlinks.length ? <pre style={{ whiteSpace: 'pre-wrap' }}>
+                        {JSON.stringify(backlinks, 4, null)}
+                    </pre> : null}
                 </ProseWrapper>
             </StyledMain>
             <TwitterReply

--- a/templates/PatternTemplate.js
+++ b/templates/PatternTemplate.js
@@ -13,6 +13,7 @@ export default function PatternTemplate({
     frontMatter,
     components,
     slug,
+    backlinks
 }) {
     function formattedDate(date) {
         return new Date(date).toLocaleDateString("en-GB", {
@@ -72,6 +73,10 @@ export default function PatternTemplate({
                 <StyledMain>
                     <ProseWrapper>
                         <MDXRemote {...source} components={components} />
+                        {/* todo: replace this with a proper component */}
+                        {backlinks.length ? <pre style={{ whiteSpace: 'pre-wrap' }}>
+                            {JSON.stringify(backlinks, 4, null)}
+                        </pre> : null}
                     </ProseWrapper>
                 </StyledMain>
             </Layout>

--- a/utils/bracketPairs.js
+++ b/utils/bracketPairs.js
@@ -1,0 +1,57 @@
+/**
+ * @param value Markdown string
+ * @returns Array of index pairs for the second opening brace matched with the second closing brace
+ */
+ export const getBracketPairs = (value) => {
+    const bracketPairs = []
+    if (value) {
+        let pointer = 0
+        let lastChar = ''
+        let bracketStart = -1
+        let codeBlock = ''
+        while (pointer < value.length) {
+            const char = value[pointer]
+            // Skip matching any double brackets inside of code blocks
+            if (char === '`') {
+                if (value[pointer + 1] === '`' && value[pointer + 2] === '`') {
+                    if (codeBlock === '```') {
+                        codeBlock = ''
+                    } else {
+                        codeBlock = '```'
+                    }
+                    pointer += 2
+                } else {
+                    if (codeBlock === '`') {
+                        codeBlock = ''
+                    } else {
+                        codeBlock = '`'
+                    }
+                }
+            }
+
+            if (!codeBlock) {
+                if (char === '[') {
+                    if (lastChar !== '[[') {
+                        if (value[pointer - 1] === '[') {
+                            lastChar = '[['
+                            bracketStart = pointer
+                        } else {
+                            lastChar = '['
+                            bracketStart = pointer
+                        }
+                    }
+                } else if (char === ']' && value[pointer - 1] === ']') {
+                    if (lastChar !== '') {
+                        // We have a pair
+                        lastChar = ''
+                        bracketPairs.push([bracketStart, pointer])
+                        bracketStart = -1
+                    }
+                }
+            }
+            pointer++
+        }
+    }
+
+    return bracketPairs
+}

--- a/utils/getAllPosts.js
+++ b/utils/getAllPosts.js
@@ -1,12 +1,12 @@
 import fs from "fs";
-import path from "path";
 import matter from "gray-matter";
+import path from "path";
+
 import {
     NOTES_PATH,
     ESSAYS_PATH,
     PATTERNS_PATH,
-    PROJECTS_PATH,
-} from "./mdxUtils";
+} from "./mdxUtils.js";
 
 // Get Post based on Slug
 export const getPostdata = async (slug) => {
@@ -24,3 +24,31 @@ export const getPostdata = async (slug) => {
 
     return post;
 };
+
+export const getAllPostData = () => {
+    // get all note files
+    const noteFiles = fs.readdirSync(NOTES_PATH);
+    // read note files
+    const notesData = noteFiles.map(file => {
+        console.log('file', file);
+
+        const note = fs.readFileSync(path.join(NOTES_PATH, file), "utf8");
+        const { content, data } = matter(note);
+        const slug = file.replace(/\.mdx?$/, "");
+        
+        console.log('data', data);
+        console.log('slug', slug)
+
+        const { title, aliases, growthStage } = data;
+
+        return {
+            content,
+            slug,
+            title,
+            aliases,
+            growthStage
+        }
+    })
+
+    return notesData;
+}

--- a/utils/getAllPosts.js
+++ b/utils/getAllPosts.js
@@ -25,30 +25,30 @@ export const getPostdata = async (slug) => {
     return post;
 };
 
+const getDataForBacklinks = (fileNames, filePath) => fileNames.map(fileName => {
+    const file = fs.readFileSync(path.join(filePath, fileName), "utf8");
+    const { content, data } = matter(file);
+    const slug = fileName.replace(/\.mdx?$/, "");
+    const { title, aliases, growthStage } = data;
+
+    return {
+        content,
+        slug,
+        title,
+        aliases,
+        growthStage
+    }
+})
+
 export const getAllPostData = () => {
     // get all note files
+    const essayFiles = fs.readdirSync(ESSAYS_PATH);
     const noteFiles = fs.readdirSync(NOTES_PATH);
-    // read note files
-    const notesData = noteFiles.map(file => {
-        console.log('file', file);
+    const patternFiles = fs.readdirSync(PATTERNS_PATH);
 
-        const note = fs.readFileSync(path.join(NOTES_PATH, file), "utf8");
-        const { content, data } = matter(note);
-        const slug = file.replace(/\.mdx?$/, "");
-        
-        console.log('data', data);
-        console.log('slug', slug)
-
-        const { title, aliases, growthStage } = data;
-
-        return {
-            content,
-            slug,
-            title,
-            aliases,
-            growthStage
-        }
-    })
-
-    return notesData;
+    const essaysData = getDataForBacklinks(essayFiles, ESSAYS_PATH);
+    const notesData = getDataForBacklinks(noteFiles, NOTES_PATH);
+    const patternsData = getDataForBacklinks(patternFiles, PATTERNS_PATH);
+    
+    return [...essaysData, ...notesData, ...patternsData];
 }

--- a/utils/getAllPosts.js
+++ b/utils/getAllPosts.js
@@ -6,7 +6,7 @@ import {
     NOTES_PATH,
     ESSAYS_PATH,
     PATTERNS_PATH,
-} from "./mdxUtils.js";
+} from "./mdxUtils";
 
 // Get Post based on Slug
 export const getPostdata = async (slug) => {

--- a/utils/getAllPosts.js
+++ b/utils/getAllPosts.js
@@ -24,31 +24,3 @@ export const getPostdata = async (slug) => {
 
     return post;
 };
-
-const getDataForBacklinks = (fileNames, filePath) => fileNames.map(fileName => {
-    const file = fs.readFileSync(path.join(filePath, fileName), "utf8");
-    const { content, data } = matter(file);
-    const slug = fileName.replace(/\.mdx?$/, "");
-    const { title, aliases, growthStage } = data;
-
-    return {
-        content,
-        slug,
-        title,
-        aliases,
-        growthStage
-    }
-})
-
-export const getAllPostData = () => {
-    // get all note files
-    const essayFiles = fs.readdirSync(ESSAYS_PATH);
-    const noteFiles = fs.readdirSync(NOTES_PATH);
-    const patternFiles = fs.readdirSync(PATTERNS_PATH);
-
-    const essaysData = getDataForBacklinks(essayFiles, ESSAYS_PATH);
-    const notesData = getDataForBacklinks(noteFiles, NOTES_PATH);
-    const patternsData = getDataForBacklinks(patternFiles, PATTERNS_PATH);
-    
-    return [...essaysData, ...notesData, ...patternsData];
-}

--- a/utils/linkify.js
+++ b/utils/linkify.js
@@ -1,0 +1,57 @@
+import linkMaps from '../links.json'
+import { getBracketPairs } from './bracketPairs'
+
+/**
+ * This replaces double bracketed links [[like this one]] in the markdown for
+ * JSX elements that link to the referenced blog post. It also adds a tooltip
+ * to the links in order to preview the title and an excerpt from the post
+ * @param content : markdown string for a blog post
+ * @param title
+ * @returns transformed markdown string for blog post
+ */
+export function linkify(content, title) {
+    if (!content) return content
+
+    const matchingBracketPairs = getBracketPairs(content)
+    if (matchingBracketPairs.length < 1) return content
+
+    // Get all outbound links for this post
+    const outboundLinks = linkMaps.find((map) => map.ids[0] === title)?.outboundLinks
+
+    let result = ''
+    let previousIndex = 0 // Starts from first character of the content string
+
+    // For each pair of brackets (link) found, append the content found before to the result,
+    // then append the link itself with JSX replacing the brackets, then append the rest of
+    // the markdown string until the next pair of brackets
+    matchingBracketPairs.forEach((pair) => {
+        const opening = pair[0]
+        const closing = pair[1]
+        const foundLinkText = content.substring(opening + 1, closing - 1)
+        const matchedOutboundLink =
+            outboundLinks &&
+            outboundLinks.find((ol) => ol.matchedId.toLowerCase() === foundLinkText.toLowerCase())
+
+        if (matchedOutboundLink) {
+            // todo: destructure title, excerpt and growthStage for your tooltip
+            const { slug } = matchedOutboundLink;
+
+            // todo: replace ordinary anchor tag for customised tooltip and internal next Link combo
+            result += content.substring(previousIndex, opening - 1) // append content up to link
+            result += `<a href={'/${slug}'}>` // append JSX opening tags
+            result += foundLinkText // skip opening brackets, then append link content (referenced post title or alias)
+            result += '</a>' // append JSX closing tags
+        } else {
+            result += content.substring(previousIndex, closing)
+        }
+        previousIndex = closing + 1 // skip closing brackets and start new loop until reaching end of the bracket pairs
+    })
+
+    const numPairs = matchingBracketPairs.length
+    const lastClosingBracket = matchingBracketPairs[numPairs - 1][1]
+
+    // Append content from last bracket pair to end of content
+    result += content.substring(lastClosingBracket + 1, content.length - 1)
+
+    return result
+}


### PR DESCRIPTION
The main functionality is in `scripts/post-links.js`, which you can run the script with `npm run build:backlinks`. It will write a json file (links.json) to your project root, which will contain all outbound and inbound links.
**NB**: you may have to run it once after merging this before running your dev server

`utils/linkify.js` is where I've replaced double brackets with normal anchor tags. I've left a **todo** in there for you to use whatever custom component you want there.

The backlinks are passed to your essay, note and pattern _templates_. Currently the data is just being dumped at the bottom of the page so you can see it. You should get a title, slug, excerpt and growth stage for each one.

### Disclaimer
> The excerpt is a bit rough at the moment. In the future I'll work out how to just render the HTML (which might be easy, I haven't tried because I didn't think of it initially) but for now I've stripped the JSX and some markdown syntax from the excerpt. I've forgotten to do that for normal markdown links `[with this](syntax)`. Sorry about that.